### PR TITLE
Strobe-based implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>"]
 
 [dependencies]
+keccak = "0.1.0"
+byteorder = "1.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "merlin"
 version = "0.1.0"
-authors = ["Henry de Valence <hdevalence@hdevalence.ca>"]
+authors = ["Henry de Valence <hdevalence@hdevalence.ca>",
+           "isis agora lovecruft <isis@patternsinthevoid.net>"]
 
 [dependencies]
 keccak = "0.1.0"
 byteorder = "1.2.4"
+
+[dev-dependencies]
+strobe-rs = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ fn encode_usize(x: usize) -> [u8; 4] {
 }
 
 /// Transcript of a public coin argument
+#[derive(Clone)]
 pub struct Transcript {
     strobe: Strobe128,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,48 @@
+
+extern crate byteorder;
+extern crate keccak;
+
+mod strobe;
+
+use strobe::Strobe128;
+
+fn encode_usize(x: usize) -> [u8; 4] {
+    use byteorder::{LittleEndian, ByteOrder};
+
+    assert!(x < (u32::max_value() as usize));
+
+    let mut buf = [0; 4];
+    LittleEndian::write_u32(&mut buf, x as u32);
+    buf
+}
+
 /// Transcript of a public coin argument
-pub struct Transcript {}
+pub struct Transcript {
+    strobe: Strobe128,
+}
 
 impl Transcript {
     /// Initialize a new transcript with the supplied label.
     pub fn new(label: &[u8]) -> Transcript {
-        // Strobe init; meta-AD(label)
-        unimplemented!();
+        Transcript {
+            strobe: Strobe128::new(label)
+        }
     }
 
     /// Commit a prover's message to the transcript.
     pub fn commit(&mut self, label: &[u8], message: &[u8]) {
-        // Strobe op: meta-AD(label || len(message)); AD(message)
-        unimplemented!();
+        let data_len = encode_usize(message.len());
+        self.strobe.meta_ad(label, false);
+        self.strobe.meta_ad(&data_len, true);
+        self.strobe.ad(message, false);
     }
 
     /// Fill the supplied buffer with the verifier's challenge bytes.
     pub fn challenge(&mut self, label: &[u8], challenge_bytes: &mut [u8]) {
-        // Strobe op: meta-PRF(label || len(challenge_bytes)); PRF into challenge_bytes
-        unimplemented!();
+        let data_len = encode_usize(challenge_bytes.len());
+        self.strobe.meta_ad(label, false);
+        self.strobe.meta_ad(&data_len, true);
+        self.strobe.prf(challenge_bytes, false);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_and_challege_should_match() {
+    fn commit_and_challenge_should_match() {
         let mut real_transcript: Transcript = Transcript::new(b"test protocol");
         let mut test_transcript: TestTranscript = TestTranscript::new(b"test protocol");
 
@@ -123,8 +123,8 @@ mod tests {
         let mut real_challenge: [u8; 32] = [0u8; 32];
         let mut test_challenge: [u8; 32] = [0u8; 32];
 
-        real_transcript.challenge(b"commit_and_challege_should_match", &mut real_challenge);
-        test_transcript.challenge(b"commit_and_challege_should_match", &mut test_challenge);
+        real_transcript.challenge(b"challenge", &mut real_challenge);
+        test_transcript.challenge(b"challenge", &mut test_challenge);
 
         assert!(real_challenge == test_challenge);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,16 @@
-
+extern crate byteorder;
 extern crate core;
+extern crate keccak;
 
 #[cfg(test)]
 extern crate strobe_rs;
-
-extern crate byteorder;
-extern crate keccak;
 
 mod strobe;
 
 use strobe::Strobe128;
 
 fn encode_usize(x: usize) -> [u8; 4] {
-    use byteorder::{LittleEndian, ByteOrder};
+    use byteorder::{ByteOrder, LittleEndian};
 
     assert!(x < (u32::max_value() as usize));
 
@@ -30,7 +28,7 @@ impl Transcript {
     /// Initialize a new transcript with the supplied label.
     pub fn new(label: &[u8]) -> Transcript {
         Transcript {
-            strobe: Strobe128::new(label)
+            strobe: Strobe128::new(label),
         }
     }
 
@@ -66,9 +64,7 @@ mod tests {
     }
 
     fn u32_to_4u8s(x: u32) -> [u8; 4] {
-        unsafe {
-            ::core::mem::transmute::<u32, [u8; 4]>(x)
-        }
+        unsafe { ::core::mem::transmute::<u32, [u8; 4]>(x) }
     }
 
     impl TestTranscript {
@@ -84,7 +80,7 @@ mod tests {
             let flags: OpFlags = OpFlags::A | OpFlags::M;
             let _ = strobe.ad(data.clone(), Some((flags, data.clone())), false);
 
-            TestTranscript{ state: strobe }
+            TestTranscript { state: strobe }
         }
 
         /// Strobe op: meta-AD(label || len(message)); AD(message)
@@ -94,7 +90,9 @@ mod tests {
             data.extend_from_slice(&u32_to_4u8s(message.len() as u32));
 
             let flags: OpFlags = OpFlags::A | OpFlags::M;
-            let _ = self.state.ad(data.clone(), Some((flags, data.clone())), false);
+            let _ = self
+                .state
+                .ad(data.clone(), Some((flags, data.clone())), false);
 
             let mut msg: Vec<u8> = Vec::with_capacity(message.len());
             msg.extend_from_slice(message);
@@ -109,7 +107,9 @@ mod tests {
             data.extend_from_slice(&u32_to_4u8s(challenge_bytes.len() as u32));
 
             let flags: OpFlags = OpFlags::I | OpFlags::A | OpFlags::C | OpFlags::M;
-            let _ = self.state.prf(challenge_bytes.len(), Some((flags, data)), false);
+            let _ = self
+                .state
+                .prf(challenge_bytes.len(), Some((flags, data)), false);
             let bytes: Vec<u8> = self.state.prf(challenge_bytes.len(), None, false);
 
             challenge_bytes.copy_from_slice(&bytes[..]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 
+extern crate core;
+
+#[cfg(test)]
+extern crate strobe_rs;
+
 extern crate byteorder;
 extern crate keccak;
 
@@ -48,8 +53,83 @@ impl Transcript {
 
 #[cfg(test)]
 mod tests {
+    use strobe_rs::OpFlags;
+    use strobe_rs::SecParam;
+    use strobe_rs::Strobe;
+
+    use super::*;
+
+    /// Test against a full strobe implementation to ensure we match the few
+    /// operations we're interested in.
+    struct TestTranscript {
+        state: Strobe,
+    }
+
+    fn u32_to_4u8s(x: u32) -> [u8; 4] {
+        unsafe {
+            ::core::mem::transmute::<u32, [u8; 4]>(x)
+        }
+    }
+
+    impl TestTranscript {
+        /// Strobe init; meta-AD(label)
+        pub fn new(label: &[u8]) -> TestTranscript {
+            let mut data: Vec<u8> = Vec::with_capacity(label.len());
+            data.extend_from_slice(label);
+
+            // XXX the new() method is doing an AD[label]() operation
+            let mut strobe: Strobe = Strobe::new(data.clone(), SecParam::B256);
+
+            // XXX what the ever loving fuck is this API
+            let flags: OpFlags = OpFlags::A | OpFlags::M;
+            let _ = strobe.ad(data.clone(), Some((flags, data.clone())), false);
+
+            TestTranscript{ state: strobe }
+        }
+
+        /// Strobe op: meta-AD(label || len(message)); AD(message)
+        pub fn commit(&mut self, label: &[u8], message: &[u8]) {
+            let mut data: Vec<u8> = Vec::with_capacity(label.len() + 4);
+            data.extend_from_slice(label);
+            data.extend_from_slice(&u32_to_4u8s(message.len() as u32));
+
+            let flags: OpFlags = OpFlags::A | OpFlags::M;
+            let _ = self.state.ad(data.clone(), Some((flags, data.clone())), false);
+
+            let mut msg: Vec<u8> = Vec::with_capacity(message.len());
+            msg.extend_from_slice(message);
+
+            self.state.ad(msg, None, false);
+        }
+
+        /// Strobe op: meta-PRF(label || len(challenge_bytes)); PRF into challenge_bytes
+        pub fn challenge(&mut self, label: &[u8], challenge_bytes: &mut [u8]) {
+            let mut data: Vec<u8> = Vec::with_capacity(label.len() + 4);
+            data.extend_from_slice(label);
+            data.extend_from_slice(&u32_to_4u8s(challenge_bytes.len() as u32));
+
+            let flags: OpFlags = OpFlags::I | OpFlags::A | OpFlags::C | OpFlags::M;
+            let _ = self.state.prf(challenge_bytes.len(), Some((flags, data)), false);
+            let bytes: Vec<u8> = self.state.prf(challenge_bytes.len(), None, false);
+
+            challenge_bytes.copy_from_slice(&bytes[..]);
+        }
+    }
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn commit_and_challege_should_match() {
+        let mut real_transcript: Transcript = Transcript::new(b"test protocol");
+        let mut test_transcript: TestTranscript = TestTranscript::new(b"test protocol");
+
+        real_transcript.commit(b"some label", b"some data");
+        test_transcript.commit(b"some label", b"some data");
+
+        let mut real_challenge: [u8; 32] = [0u8; 32];
+        let mut test_challenge: [u8; 32] = [0u8; 32];
+
+        real_transcript.challenge(b"commit_and_challege_should_match", &mut real_challenge);
+        test_transcript.challenge(b"commit_and_challege_should_match", &mut test_challenge);
+
+        assert!(real_challenge == test_challenge);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,6 @@ mod tests {
         state: Strobe,
     }
 
-    fn u32_to_4u8s(x: u32) -> [u8; 4] {
-        unsafe { ::core::mem::transmute::<u32, [u8; 4]>(x) }
-    }
-
     impl TestTranscript {
         /// Strobe init; meta-AD(label)
         pub fn new(label: &[u8]) -> TestTranscript {
@@ -87,7 +83,7 @@ mod tests {
         pub fn commit(&mut self, label: &[u8], message: &[u8]) {
             let mut data: Vec<u8> = Vec::with_capacity(label.len() + 4);
             data.extend_from_slice(label);
-            data.extend_from_slice(&u32_to_4u8s(message.len() as u32));
+            data.extend_from_slice(&encode_usize(message.len()));
 
             let flags: OpFlags = OpFlags::A | OpFlags::M;
             let _ = self
@@ -104,7 +100,7 @@ mod tests {
         pub fn challenge(&mut self, label: &[u8], challenge_bytes: &mut [u8]) {
             let mut data: Vec<u8> = Vec::with_capacity(label.len() + 4);
             data.extend_from_slice(label);
-            data.extend_from_slice(&u32_to_4u8s(challenge_bytes.len() as u32));
+            data.extend_from_slice(&encode_usize(challenge_bytes.len()));
 
             let flags: OpFlags = OpFlags::I | OpFlags::A | OpFlags::C | OpFlags::M;
             let _ = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,15 +66,8 @@ mod tests {
     impl TestTranscript {
         /// Strobe init; meta-AD(label)
         pub fn new(label: &[u8]) -> TestTranscript {
-            let mut data: Vec<u8> = Vec::with_capacity(label.len());
-            data.extend_from_slice(label);
-
             // XXX the new() method is doing an AD[label]() operation
-            let mut strobe: Strobe = Strobe::new(data.clone(), SecParam::B128);
-
-            // XXX what the ever loving fuck is this API
-            let flags: OpFlags = OpFlags::A | OpFlags::M;
-            let _ = strobe.ad(data.clone(), Some((flags, data.clone())), false);
+            let mut strobe: Strobe = Strobe::new(label.to_vec(), SecParam::B128);
 
             TestTranscript { state: strobe }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,16 +96,17 @@ mod tests {
             self.state.ad(msg, None, false);
         }
 
-        /// Strobe op: meta-PRF(label || len(challenge_bytes)); PRF into challenge_bytes
+        /// Strobe op: meta-AD(label || len(challenge_bytes)); PRF into challenge_bytes
         pub fn challenge(&mut self, label: &[u8], challenge_bytes: &mut [u8]) {
             let mut data: Vec<u8> = Vec::with_capacity(label.len() + 4);
             data.extend_from_slice(label);
             data.extend_from_slice(&encode_usize(challenge_bytes.len()));
 
-            let flags: OpFlags = OpFlags::I | OpFlags::A | OpFlags::C | OpFlags::M;
+            let flags: OpFlags = OpFlags::A | OpFlags::M;
             let _ = self
                 .state
-                .prf(challenge_bytes.len(), Some((flags, data)), false);
+                .ad(data.clone(), Some((flags, data.clone())), false);
+
             let bytes: Vec<u8> = self.state.prf(challenge_bytes.len(), None, false);
 
             challenge_bytes.copy_from_slice(&bytes[..]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ mod tests {
             data.extend_from_slice(label);
 
             // XXX the new() method is doing an AD[label]() operation
-            let mut strobe: Strobe = Strobe::new(data.clone(), SecParam::B256);
+            let mut strobe: Strobe = Strobe::new(data.clone(), SecParam::B128);
 
             // XXX what the ever loving fuck is this API
             let flags: OpFlags = OpFlags::A | OpFlags::M;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,18 +115,18 @@ mod tests {
 
     #[test]
     fn commit_and_challenge_should_match() {
-        let mut real_transcript: Transcript = Transcript::new(b"test protocol");
-        let mut test_transcript: TestTranscript = TestTranscript::new(b"test protocol");
+        let mut real_transcript = Transcript::new(b"test protocol");
+        let mut test_transcript = TestTranscript::new(b"test protocol");
 
         real_transcript.commit(b"some label", b"some data");
         test_transcript.commit(b"some label", b"some data");
 
-        let mut real_challenge: [u8; 32] = [0u8; 32];
-        let mut test_challenge: [u8; 32] = [0u8; 32];
+        let mut real_challenge = [0u8; 32];
+        let mut test_challenge = [0u8; 32];
 
         real_transcript.challenge(b"challenge", &mut real_challenge);
         test_transcript.challenge(b"challenge", &mut test_challenge);
 
-        assert!(real_challenge == test_challenge);
+        assert_eq!(real_challenge, test_challenge);
     }
 }

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -17,6 +17,7 @@ const FLAG_K: u8 = 1 << 5;
 /// A Strobe context for the 128-bit security level.
 ///
 /// Only `meta-AD`, `AD`, and `PRF` operations are supported.
+#[derive(Clone)]
 pub struct Strobe128 {
     state: [u8; 200],
     pos: u8,

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -87,6 +87,7 @@ impl Strobe128 {
     fn squeeze(&mut self, data: &mut [u8], force_f: bool) {
         for byte in data {
             *byte = self.state[self.pos as usize];
+            self.state[self.pos as usize] = 0;
             self.pos += 1;
             if self.pos == STROBE_R {
                 self.run_f();

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -8,6 +8,8 @@ const STROBE_R: u8 = 166;
 const FLAG_I: u8 = 1 << 0;
 const FLAG_A: u8 = 1 << 1;
 const FLAG_C: u8 = 1 << 2;
+// This implementation does not use the transport flag.
+#[allow(dead_code)]
 const FLAG_T: u8 = 1 << 3;
 const FLAG_M: u8 = 1 << 4;
 const FLAG_K: u8 = 1 << 5;

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -66,8 +66,9 @@ impl Strobe128 {
         self.state[self.pos as usize] ^= self.pos_begin;
         self.state[(self.pos + 1) as usize] ^= 0x04;
         self.state[(STROBE_R + 1) as usize] ^= 0x80;
-
         keccak::f1600(unsafe { ::std::mem::transmute(&mut self.state) });
+        self.pos = 0;
+        self.pos_begin = 0;
     }
 
     fn absorb(&mut self, data: &[u8], force_f: bool) {

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -1,0 +1,121 @@
+//! Minimal implementatation of (parts of) Strobe.
+
+use keccak;
+
+/// Strobe R value; security level 128 is hardcoded
+const STROBE_R: u8 = 166;
+
+const FLAG_I: u8 = 1 << 0;
+const FLAG_A: u8 = 1 << 1;
+const FLAG_C: u8 = 1 << 2;
+const FLAG_T: u8 = 1 << 3;
+const FLAG_M: u8 = 1 << 4;
+const FLAG_K: u8 = 1 << 5;
+
+/// A Strobe context for the 128-bit security level.
+///
+/// Only `meta-AD`, `AD`, and `PRF` operations are supported.
+pub struct Strobe128 {
+    state: [u8; 200],
+    pos: u8,
+    pos_begin: u8,
+    cur_flags: u8,
+}
+
+impl Strobe128 {
+    pub fn new(protocol_label: &[u8]) -> Strobe128 {
+        let initial_state = {
+            let mut st = [0u8; 200];
+            st[0..6].copy_from_slice(&[1, STROBE_R + 2, 1, 0, 1, 96]);
+            st[6..18].copy_from_slice(b"STROBEv1.0.2");
+            keccak::f1600(unsafe { ::std::mem::transmute(&mut st) });
+
+            st
+        };
+
+        let mut strobe = Strobe128 {
+            state: initial_state,
+            pos: 0,
+            pos_begin: 0,
+            cur_flags: 0,
+        };
+
+        strobe.meta_ad(protocol_label, false);
+
+        strobe
+    }
+
+    pub fn meta_ad(&mut self, data: &[u8], more: bool) {
+        self.begin_op(FLAG_M | FLAG_A, more);
+        self.absorb(data, false);
+    }
+
+    pub fn ad(&mut self, data: &[u8], more: bool) {
+        self.begin_op(FLAG_A, more);
+        self.absorb(data, false);
+    }
+
+    pub fn prf(&mut self, data: &mut [u8], more: bool) {
+        self.begin_op(FLAG_I | FLAG_A | FLAG_C, more);
+        self.squeeze(data, false);
+    }
+}
+
+impl Strobe128 {
+    fn run_f(&mut self) {
+        self.state[self.pos as usize] ^= self.pos_begin;
+        self.state[(self.pos + 1) as usize] ^= 0x04;
+        self.state[(STROBE_R + 1) as usize] ^= 0x80;
+
+        keccak::f1600(unsafe { ::std::mem::transmute(&mut self.state) });
+    }
+
+    fn absorb(&mut self, data: &[u8], force_f: bool) {
+        for byte in data {
+            self.state[self.pos as usize] ^= byte;
+            self.pos += 1;
+            if self.pos == STROBE_R {
+                self.run_f();
+            }
+        }
+        if force_f && self.pos != 0 {
+            self.run_f();
+        }
+    }
+
+    fn squeeze(&mut self, data: &mut [u8], force_f: bool) {
+        for byte in data {
+            *byte = self.state[self.pos as usize];
+            self.pos += 1;
+            if self.pos == STROBE_R {
+                self.run_f();
+            }
+        }
+        if force_f && self.pos != 0 {
+            self.run_f();
+        }
+    }
+
+    fn begin_op(&mut self, flags: u8, more: bool) {
+        // Check if we're continuing an operation
+        if more {
+            assert_eq!(
+                self.cur_flags, flags,
+                "You tried to continue op {:#b} but changed flags to {:#b}",
+                self.cur_flags, flags,
+            );
+            return;
+        }
+
+        // Skip adjusting direction information (we just use AD, PRF)
+
+        // Force running F if C or K is set
+        let force_f = 0 != (flags & (FLAG_C | FLAG_K));
+
+        let old_begin = self.pos_begin;
+        self.pos_begin = self.pos + 1;
+        self.cur_flags = flags;
+
+        self.absorb(&[old_begin, flags], force_f);
+    }
+}


### PR DESCRIPTION
The test code from #2 is included in this PR -- I had to change it because my description of the Strobe operations in #1 was wrong.

This implements a small subset of Strobe at the 128-bit security level to implement the transcript.

The commit function is implemented as:
```
meta-AD(label || LE32(msg.len()))
AD(msg)
```
The challenge function is implemented as:
```
meta-AD(label || LE32(challenge.len()))
challenge <- PRF(challenge.len())
```