### PR TITLE
Zero the STROBE state on drop.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ authors = ["Henry de Valence <hdevalence@hdevalence.ca>",
 [dependencies]
 keccak = "0.1.0"
 byteorder = "1.2.4"
+clear_on_drop = "0.2.3"
 
 [dev-dependencies]
 strobe-rs = "0.3"
 
 [features]
-# Used for doc includes
-nightly = []
+nightly = ["clear_on_drop/nightly"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
 extern crate byteorder;
+extern crate clear_on_drop;
 extern crate core;
 extern crate keccak;
 

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -25,6 +25,13 @@ pub struct Strobe128 {
     cur_flags: u8,
 }
 
+impl Drop for Strobe128 {
+    fn drop(&mut self) {
+        use clear_on_drop::clear::Clear;
+        self.state.clear();
+    }
+}
+
 impl Strobe128 {
     pub fn new(protocol_label: &[u8]) -> Strobe128 {
         let initial_state = {


### PR DESCRIPTION
To check that it is actually zeroed:

```
~/c/merlin (zero-state|✚3…) $ cargo asm "<merlin::strobe::Strobe128 as core::ops::drop::Drop>::drop"
<merlin::strobe::Strobe128 as core::ops::drop::Drop>::drop:
 xorps   xmm0, xmm0
 movups  xmmword, ptr, [rdi, +, 176], xmm0
 movups  xmmword, ptr, [rdi, +, 160], xmm0
 movups  xmmword, ptr, [rdi, +, 144], xmm0
 movups  xmmword, ptr, [rdi, +, 128], xmm0
 movups  xmmword, ptr, [rdi, +, 112], xmm0
 movups  xmmword, ptr, [rdi, +, 96], xmm0
 movups  xmmword, ptr, [rdi, +, 80], xmm0
 movups  xmmword, ptr, [rdi, +, 64], xmm0
 movups  xmmword, ptr, [rdi, +, 48], xmm0
 movups  xmmword, ptr, [rdi, +, 32], xmm0
 movups  xmmword, ptr, [rdi, +, 16], xmm0
 movups  xmmword, ptr, [rdi], xmm0
 mov     qword, ptr, [rdi, +, 192], 0
 jmp     clear_on_drop_hide@PLT
```